### PR TITLE
Remove dependency on assert

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@
  */
 "use strict";
 
-var assert = require("assert"),
-    loop = require("simple-loop");
+var loop = require("simple-loop");
 
 /**
  * Make a diff between two objects
@@ -42,8 +41,12 @@ var assert = require("assert"),
  * @returns object
  */
 module.exports = function shallowDiff(base, compared) {
-    assert(typeof base == "object", "the first object to compare with shallowDiff needs to be an object");
-    assert(typeof compared == "object", "the second object to compare with shallowDiff needs to be an object");
+    if (typeof base != "object") throw new TypeError("shallow-diff: " +
+      "the first object to compare with shallowDiff needs to be an object"
+    );
+    if (typeof compared != "object") throw new TypeError("shallow-diff: " +
+      "the second object to compare with shallowDiff needs to be an object"
+    );
 
     var unchanged = [],
         updated = [],


### PR DESCRIPTION
Hi @podefr, I want to use this lib in a browser. There’s two problems with that:
- The module _assert_ says the following in a comment right upfront:

``` js
// THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!
```
- The minified code of the lib itself is just above 700 bytes. The minified code after webpacking (together with _assert_) is over 17 KiB!
