### PR TITLE
Update simple-loop dependency to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "mocha": "^2.2.4"
   },
   "dependencies": {
-    "simple-loop": "0.0.2"
+    "simple-loop": "0.0.4"
   }
 }


### PR DESCRIPTION
Trying to use this in React Native, but `assert` causes issues. This drops the need for `assert` entirely.
